### PR TITLE
Add Astra series

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -35,6 +35,9 @@
 		<meta property="authority" refines="#subject-2">LCSH</meta>
 		<meta property="term" refines="#subject-2">sh2008111729</meta>
 		<meta property="se:subject">Science Fiction</meta>
+		<meta id="collection-1" property="belongs-to-collection">Astra</meta>
+		<meta property="collection-type" refines="#collection-1">series</meta>
+		<meta property="group-position" refines="#collection-1">2</meta>
 		<dc:description id="description">Two human protagonists find themselves on opposite sides of an inter-species war.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;This sequel to &lt;i&gt;The Stars Are Ours!&lt;/i&gt; was first published in 1957 by the World Publishing Company. It continues the tale of the humans who escaped an anti-intellectual Earth and founded a colony on Astra, a planet across the galaxy. Astra has a vibrant, intelligent species, as well as the ruins of a much older civilization.&lt;/p&gt;


### PR DESCRIPTION
Wikipedia calls *Star Born*’s series “[Astra, or Pax](https://en.wikipedia.org/wiki/Andre_Norton_bibliography#Astra,_or_Pax).”

I went with Astra rather than Pax. In the first book humans travel *ad astra*, and in the end name the planet they’ve settled on “Astra”; it is the main setting of the second book. The Peacemen of the Company of Pax are the villains of the first book, but according to Wikipedia’s plot summary collapsed centuries before the second book took place.